### PR TITLE
feat(issue-templates): add Related section for context linking

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -6,6 +6,11 @@ labels: 'bug'
 
 ---
 
+### Related (optional)
+
+- #[issue/PR number]: [brief description]
+- [external link]: [brief description]
+
 ### What Happened?
 
 **Expected**: [What should happen]

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -6,6 +6,11 @@ labels: 'enhancement'
 
 ---
 
+### Related (optional)
+
+- #[issue/PR number]: [brief description]
+- [external link]: [brief description]
+
 ### Problem
 
 [Description of the problem or limitation this addresses]

--- a/prompts/prompt-issue-gen.md
+++ b/prompts/prompt-issue-gen.md
@@ -24,7 +24,10 @@ You are a technical documentation specialist creating issues that communicate pr
 
 - Search for issue templates in repository
 - Classify issue type from user input (bug vs feature vs other)
-- Search codebase for related issues, recent changes, existing functionality
+- **Proactively search for related context**:
+  - Use GitHub/GitLab MCP tools (if available) to search existing issues, PRs, discussions
+  - Search codebase for recent changes, related functionality, error patterns
+  - Identify dependencies or blockers from prior work
 - Extract all key information from user: symptoms, desired functionality, technical requirements, context
 
 ### STEP 2: Classify & Consult User
@@ -39,12 +42,13 @@ You are a technical documentation specialist creating issues that communicate pr
 
 - **Bug Report**: Reproduction steps, expected/actual behavior, environment details
 - **Feature Request**: Problem statement, proposed solution, alternatives considered
-- **All Types**: Priority level, related issues, dependencies
+- **All Types**: Related issues/PRs/links for the "Related" section, priority level
 
 ### STEP 3: Generate Issue
 
 - Follow discovered template structure exactly with all required fields populated
 - Include conventional title format matching template frontmatter (bug/feat with component scope)
+- Populate "Related" section with discovered issues/PRs/links (omit if none found)
 - Organize content by template sections using dash bullets for clarity
 - Each bullet contains specific, actionable details with no overlap
 - Apply KISS & DRY: concise points that capture all critical information
@@ -68,4 +72,4 @@ feat(component): brief description
 [complete issue content following template structure]
 ```
 
-> Issue Generation Prompt v2.0.0 - KemingHe/common-devx
+> Issue Generation Prompt v2.1.0 - KemingHe/common-devx


### PR DESCRIPTION
closes #19

CHANGES
- Add optional "Related" section to bug-report.md and feature-request.md
- Update prompt-issue-gen.md to search for and populate related context
- Add guidance for using GitHub/GitLab MCP tools in issue creation