### PR TITLE
feat(contacts-template): add ToC and section headings

### DIFF
--- a/contacts-template.md
+++ b/contacts-template.md
@@ -1,21 +1,32 @@
-# Contacts
+# Contacts - [Description]
 
 > **Last Updated**: [YYYY-MM-DD] by [First Name Last Name]
 
 This document provides essential contact information for the [project/team name] team, helping developers direct questions to the appropriate specialist and prepare for meetings.
 
-- **[First Name Last Name (Optional [Preferred Name])]**
-  - **Title**: [Job Title], [Company/Organization]
-  - **Phone**: [+0 000-000-0000]
-  - **Email**: [email@domain.com](mailto:[email@domain.com])
-  - **GitHub**: [github-username](https://github.com/[github-username])
-  - **Timezone**: [Timezone Name (Abbreviation, UTC±X)]
-  - **Specializations**:
-    - [Specific areas of expertise beneficial to the team]
-  - **Notes**:
-    - [Important scheduling or communication notes]
-    - [Additional context or preferences]
+## Table of Contents
+
+- [Contacts - \[Description\]](#contacts---description)
+  - [Table of Contents](#table-of-contents)
+  - [\[Domain\] Contacts](#domain-contacts)
+    - [First Name Last Name](#first-name-last-name)
+
+## [Domain] Contacts
+
+### First Name Last Name
+
+- **Title**: [Job Title], [Company/Organization]
+- **Phone**: [+0 000-000-0000] or ???
+- **Email**: [email@domain.com](mailto:email@domain.com) or ???
+- **LinkedIn**: [linkedin-username](https://www.linkedin.com/in/linkedin-username/) or ???
+- **GitHub**: [github-username](https://github.com/github-username) or N/A or ???
+- **Timezone**: [Timezone Name (Abbreviation, UTC±X)] or ???
+- **Specializations**:
+  - [Specific areas of expertise beneficial to the team]
+- **Notes**:
+  - [Important scheduling or communication notes]
+  - [Additional context or preferences]
 
 ---
 
-> Contacts Template v1.0.2 - KemingHe/common-devx
+> Contacts Template v1.1.0 - KemingHe/common-devx


### PR DESCRIPTION
closes #28
closes #27

CHANGES
- Add auto-generated Table of Contents with nested links
- Add [Domain] Contacts grouping section for organizing by domain
- Convert name entries from bullet lists to section headings (###)
- Enhance placeholders with "or ???" and "or N/A" fallbacks
- Update main title to include [Description] placeholder
- Bump version from v1.0.2 to v1.1.0

IMPACT
- Scales efficiently for 20+ contacts with navigable structure
- Enables direct cross-document referencing via anchors (contacts.md#first-name-last-name)
- Improves document navigation with ToC for quick lookups
- Supports domain-based organization for multi-team projects

TECHNICAL NOTES
- Feature proposed by Keming for personal contact management
- Section headings automatically generate markdown anchors for # lookup
- Hierarchical structure supports unlimited domain groupings