### PR TITLE
refactor(skill-creation): consolidate to template

### DIFF
--- a/agent-skills/skill-creation/README.md
+++ b/agent-skills/skill-creation/README.md
@@ -1,6 +1,6 @@
 # README - Skill Creation
 
-> **Last Updated**: 2026-02-05 by Keming He
+> **Last Updated**: 2026-02-16 by Keming He
 
 Create or refactor Agent Skills following the agentskills.io specification.
 
@@ -16,47 +16,8 @@ Tell your AI agent: "Create a skill for [task]" or "Convert this prompt to a ski
 
 ## Files
 
-```plaintext
-skill-creation/
-├── SKILL.md                    # AI instructions for creating skills
-├── README.md                   # This file
-└── assets/
-    └── skill-template.md       # SKILL.md template with placeholders
-```
-
-## Skill Structure
-
-Every skill follows this structure:
-
-```plaintext
-skill-name/
-├── SKILL.md              # Required: frontmatter + instructions
-├── README.md             # Required: human documentation
-├── assets/               # Optional: templates, static resources
-├── references/           # Optional: detailed docs, acceptance criteria
-└── scripts/              # Optional: executable code
-```
-
-## Frontmatter Requirements
-
-```yaml
----
-name: skill-name          # Must match directory name
-description: |            # What + when + triggers
-  What this skill does.
-  When to use it. Triggers: "keyword".
-license: MIT              # Optional: license reference
-metadata:
-  author: Name
-  version: "1.0.0"
----
-```
-
-## Constraints
-
-- QWERTY keyboard typeable only (no em-dashes, smart quotes, emojis). Exception: `↑` for ToC
-- Keep SKILL.md under 500 lines
-- Directory name must match `name` field in frontmatter
+- [`SKILL.md`](./SKILL.md) - AI instructions for creating skills
+- [`assets/skill-template.md`](./assets/skill-template.md) - SKILL.md template with placeholders
 
 ## Related
 

--- a/agent-skills/skill-creation/SKILL.md
+++ b/agent-skills/skill-creation/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Skill Creation
@@ -77,62 +77,23 @@ skill-name/
 - No consecutive hyphens (`--`)
 - Directory name must match `name` field in frontmatter
 
-### Step 3: Write SKILL.md Frontmatter
+### Step 3: Write SKILL.md
 
-Required and recommended fields:
+Read the skill template from Asset Resolution. Fill in all bracket placeholders with project-specific values.
 
-```yaml
----
-name: skill-name
-description: |
-  One-line summary of what this skill does.
-  When to use it and trigger keywords.
-license: MIT
-metadata:
-  author: AuthorName
-  version: "1.0.0"
----
-```
+**Frontmatter guidelines**:
 
-**Description guidelines**:
+- `description`: 1-1024 chars. First sentence: what the skill does. Second sentence: when to use it, including trigger keywords.
+- `license`: Project license name or file reference
+- See Specification Reference below for all available fields
 
-- 1-1024 characters
-- First sentence: what the skill does
-- Second sentence: when to use it
-- Include trigger keywords for agent discovery
+**Body guidelines**:
 
-### Step 4: Write SKILL.md Body
+- Adapt template sections to the skill's domain - remove unused optional sections, add domain-specific ones
+- For skills interacting with external systems, uncomment and fill in the Safety section (the template provides the pattern)
+- Keep under 500 lines; move supplementary detail to `references/`
 
-Follow this structure (adapt sections as needed):
-
-1. **Title**: `# Skill Name` (human-readable)
-2. **Temporary persona**: Brief expertise statement (replaces ROLE for skill context)
-3. **When to Use**: Scenarios that trigger this skill
-4. **Asset Resolution**: How to find templates (local first, then search)
-5. **Safety section**: For skills with side effects - safe vs forbidden operations
-6. **Process**: Step-by-step instructions for the agent
-7. **Output Format**: Expected output structure
-8. **Constraints**: Rules and limitations
-9. **Examples**: Good/bad examples if helpful
-10. **Footer**: Version tag `> Skill Name Skill vX.Y.Z - Repo`
-
-**Safety section pattern** (for skills that interact with external systems):
-
-```markdown
-## [System] Operations (Read-Only)
-
-This skill performs read-only reconnaissance. Never modify [system] state.
-
-**Setup**: [Any required preparation, e.g., pipe to cat for git]
-
-**Safe commands**: [List of allowed operations]
-
-**Forbidden operations**: [List of prohibited actions]
-
-**Prefer remote tools**: [MCP/API alternatives when available]
-```
-
-### Step 5: Create Assets (if needed)
+### Step 4: Create Assets (if needed)
 
 Place templates in `assets/` subdirectory:
 
@@ -140,28 +101,9 @@ Place templates in `assets/` subdirectory:
 - Templates should be self-documenting with placeholders
 - Include version footer in templates
 
-### Step 6: Create README.md
+### Step 5: Create README.md
 
-Human-readable documentation:
-
-```markdown
-# Skill Name
-
-Brief description for humans browsing the repository.
-
-## Quick Start
-
-How to use this skill with your AI agent.
-
-## Files
-
-- `SKILL.md` - AI instructions
-- `assets/` - Templates used by this skill
-
-## Related
-
-Links to related skills or documentation.
-```
+Create human-readable documentation with: description, quick start, file listing, and related links. Follow the pattern of existing skill READMEs in the repository.
 
 ## Output Format
 
@@ -208,4 +150,4 @@ Full specification: [agentskills.io/specification](https://agentskills.io/specif
 
 ---
 
-> Skill Creation Skill v1.1.0 - KemingHe/common-devx
+> Skill Creation Skill v1.2.0 - KemingHe/common-devx

--- a/agent-skills/skill-creation/assets/skill-template.md
+++ b/agent-skills/skill-creation/assets/skill-template.md
@@ -3,7 +3,7 @@ name: [skill-name]
 description: |
   [One-line summary of what this skill does.]
   [When to use it.] Triggers: "[keyword1]", "[keyword2]", "[keyword3]".
-license: MIT
+license: [license]
 metadata:
   author: [AuthorName]
   version: "1.0.0"


### PR DESCRIPTION
closes #42

CHANGES
- skill-template.md
  - Replace license: MIT with license: [license] bracket placeholder
- SKILL.md
  - Consolidate Steps 3-6 into Steps 3-5, reference template instead of inlining duplicated examples
  - Remove inline YAML frontmatter, body structure, safety pattern, and README template
  - Bump version 1.1.0 -> 1.2.0
- README.md
  - Strip duplicated sections (directory tree, frontmatter example, constraints)
  - Match lean pattern of github-issue and github-pull-request READMEs
  - Update Last Updated to 2026-02-16

IMPACT
- Template is now the single source of truth for skill structure and placeholders
- All bracket placeholder fields are consistent (no more bare MIT default)
