### PR TITLE
fix(skills): add unified doc output constraints

### DIFF
--- a/agent-skills/commit-message/README.md
+++ b/agent-skills/commit-message/README.md
@@ -1,6 +1,6 @@
 # README - Commit Message Generation
 
-> **Last Updated**: 2026-02-05 by Keming He
+> **Last Updated**: 2026-02-22 by Keming He
 
 Generate conventional commit messages by analyzing staged changes and repository context.
 
@@ -35,7 +35,7 @@ commit-message/
 | `refactor` | Code change, no feature/fix |
 | `chore` | Maintenance, dependencies |
 
-## Constraints
+## Skill Constraints
 
 - Title max 50 characters, imperative mood
 - QWERTY keyboard typeable only (no em-dashes, smart quotes, emojis)

--- a/agent-skills/commit-message/SKILL.md
+++ b/agent-skills/commit-message/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # Commit Message Generation
@@ -122,15 +122,27 @@ type(scope): brief description in imperative mood
 [body content per template]
 ```
 
-## Constraints
+## General Doc Constraints
+
+Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
+
+- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
+- **Bullets**: Use dash (`-`) for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line; split into separate distinct bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted.
+- **Prose lines**: One sentence per line; never wrap mid-sentence to a continuation line
+- **Optional sections**: Strip `(optional)` or any parenthetical conditional label (e.g., `(if operational)`) from section headers when populating; omit the entire section (header and body) when unused
+- **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections
+- **Completeness**: Populate all template placeholders with actual content; do not leave bracketed placeholders (e.g., `[Job Title]`), `[TODO]`, or `[TBD]` in generated output
+- **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap
+
+> General Doc Constraints v1.0.0 - KemingHe/common-devx
+
+## Skill Constraints
 
 - **Title**: Max 50 characters, imperative mood
 - **Plaintext only**: No markdown formatting (no `**bold**`, `_italic_`, `` `code` ``, links). Use dashes and indents for structure
 - **Completeness**: Capture all significant changes
-- **KISS and DRY**: Each bullet conveys unique information
 - **Sections**: Include only sections with meaningful content
 - **Issue linking**: Use separate "closes #X" for each resolved issue
-- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode
 
 ## Examples
 
@@ -164,4 +176,4 @@ BREAKING CHANGES
 
 ---
 
-> Commit Message Generation Skill v2.0.0 - KemingHe/common-devx
+> Commit Message Generation Skill v2.1.0 - KemingHe/common-devx

--- a/agent-skills/contacts/SKILL.md
+++ b/agent-skills/contacts/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Contact Management
@@ -104,16 +104,28 @@ Present contact entry in markdown following template structure:
 - `???` = Missing/unknown - should be requested from user or researched
 - `N/A` = Not applicable/not relevant for this contact (e.g., no GitHub for non-developer)
 
-## Constraints
+## General Doc Constraints
+
+Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
+
+- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
+- **Bullets**: Use dash (`-`) for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line; split into separate distinct bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted.
+- **Prose lines**: One sentence per line; never wrap mid-sentence to a continuation line
+- **Optional sections**: Strip `(optional)` or any parenthetical conditional label (e.g., `(if operational)`) from section headers when populating; omit the entire section (header and body) when unused
+- **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections
+- **Completeness**: Populate all template placeholders with actual content; do not leave bracketed placeholders (e.g., `[Job Title]`), `[TODO]`, or `[TBD]` in generated output
+- **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap
+
+> General Doc Constraints v1.0.0 - KemingHe/common-devx
+
+## Skill Constraints
 
 - **Template as scaffold**: Use discovered templates as minimum structure
 - **Validation first**: Always validate email format and required fields before adding
 - **Duplicate check**: Search existing contacts before adding new entry
 - **User confirmation**: Always confirm before writing changes
 - **Privacy awareness**: Only include information user has permission to store
-- **KISS and DRY**: Each field conveys unique information
-- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode
 
 ---
 
-> Contact Management Skill v1.0.0 - KemingHe/common-devx
+> Contact Management Skill v1.1.0 - KemingHe/common-devx

--- a/agent-skills/documentation-review/README.md
+++ b/agent-skills/documentation-review/README.md
@@ -1,6 +1,6 @@
 # README - Documentation Review
 
-> **Last Updated**: 2026-02-05 by Keming He
+> **Last Updated**: 2026-02-22 by Keming He
 
 Review and correct documentation for consistency, correctness, and drift. Documentation edits only - no functional code changes.
 
@@ -21,6 +21,7 @@ Ask your AI agent to review documentation:
 | Completeness | Required sections, no placeholders |
 | Freshness | Last Updated dates, versions |
 | Linter | IDE/editor warnings when available |
+| Output quality | Soft-wrapped lines, orphaned optional labels, unfilled placeholders |
 
 ## Common Catches
 

--- a/agent-skills/documentation-review/SKILL.md
+++ b/agent-skills/documentation-review/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Documentation Review
@@ -42,6 +42,7 @@ Determine files to review:
 | **Freshness** | Last Updated date, version numbers, changelog entries |
 | **Characters** | QWERTY-only, no em-dashes/smart quotes/emojis (exception: `↑`) |
 | **Linter** | Check IDE/editor linter errors when available |
+| **Output quality** | Soft-wrapped bullets or prose continuation lines; orphaned conditional section labels (e.g., `(optional)` still present after populating); non-QWERTY characters; unfilled bracketed placeholders; terminology inconsistency; KISS/DRY violations |
 
 ### Step 3: Check Linter Errors
 
@@ -82,14 +83,27 @@ Summarize with:
 - **Placeholder remnants**: `[TODO]` or `[TBD]` left in final docs
 - **Linter errors**: Ignoring IDE warnings on markdown files
 
-## Constraints
+## General Doc Constraints
+
+Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
+
+- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
+- **Bullets**: Use dash (`-`) for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line; split into separate distinct bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted.
+- **Prose lines**: One sentence per line; never wrap mid-sentence to a continuation line
+- **Optional sections**: Strip `(optional)` or any parenthetical conditional label (e.g., `(if operational)`) from section headers when populating; omit the entire section (header and body) when unused
+- **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections
+- **Completeness**: Populate all template placeholders with actual content; do not leave bracketed placeholders (e.g., `[Job Title]`), `[TODO]`, or `[TBD]` in generated output
+- **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap
+
+> General Doc Constraints v1.0.0 - KemingHe/common-devx
+
+## Skill Constraints
 
 - **Documentation only**: Edit txt, md, mdx, rst files - no functional code changes
 - **Structured output**: Always use table format for findings
 - **Prioritized**: Critical issues (broken links, wrong versions) before style issues
 - **Linter-aware**: Check and report linter errors when tooling is available
-- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
 
 ---
 
-> Documentation Review Skill v1.1.0 - KemingHe/common-devx
+> Documentation Review Skill v1.2.0 - KemingHe/common-devx

--- a/agent-skills/github-issue/SKILL.md
+++ b/agent-skills/github-issue/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "3.0.0"
+  version: "3.1.0"
 ---
 
 # GitHub Issue Generation
@@ -84,14 +84,26 @@ feat(component): brief description
 [complete issue content following template structure]
 ```
 
-## Constraints
+## General Doc Constraints
+
+Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
+
+- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
+- **Bullets**: Use dash (`-`) for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line; split into separate distinct bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted.
+- **Prose lines**: One sentence per line; never wrap mid-sentence to a continuation line
+- **Optional sections**: Strip `(optional)` or any parenthetical conditional label (e.g., `(if operational)`) from section headers when populating; omit the entire section (header and body) when unused
+- **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections
+- **Completeness**: Populate all template placeholders with actual content; do not leave bracketed placeholders (e.g., `[Job Title]`), `[TODO]`, or `[TBD]` in generated output
+- **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap
+
+> General Doc Constraints v1.0.0 - KemingHe/common-devx
+
+## Skill Constraints
 
 - **Title**: Max 50 characters, imperative mood, `bug(scope):` or `feat(scope):` format
 - **Template as scaffold**: Use discovered templates as minimum structure, enrich appropriately
 - **Completeness**: Capture all technical details, error messages, requirements
-- **KISS and DRY**: Each section conveys unique, specific information - no fluff
-- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode
 
 ---
 
-> GitHub Issue Generation Skill v3.0.0 - KemingHe/common-devx
+> GitHub Issue Generation Skill v3.1.0 - KemingHe/common-devx

--- a/agent-skills/github-pull-request/SKILL.md
+++ b/agent-skills/github-pull-request/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "3.0.0"
+  version: "3.1.0"
 ---
 
 # GitHub Pull Request Generation
@@ -116,16 +116,28 @@ type(scope): brief description
 [complete PR description following template structure]
 ```
 
-## Constraints
+## General Doc Constraints
+
+Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
+
+- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
+- **Bullets**: Use dash (`-`) for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line; split into separate distinct bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted.
+- **Prose lines**: One sentence per line; never wrap mid-sentence to a continuation line
+- **Optional sections**: Strip `(optional)` or any parenthetical conditional label (e.g., `(if operational)`) from section headers when populating; omit the entire section (header and body) when unused
+- **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections
+- **Completeness**: Populate all template placeholders with actual content; do not leave bracketed placeholders (e.g., `[Job Title]`), `[TODO]`, or `[TBD]` in generated output
+- **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap
+
+> General Doc Constraints v1.0.0 - KemingHe/common-devx
+
+## Skill Constraints
 
 - **Title**: Max 50 characters, imperative mood, conventional commit format
 - **Template as scaffold**: Use discovered templates as minimum structure, enrich appropriately
 - **Comprehensive analysis**: Use git commands, MCP tools, codebase search
-- **KISS and DRY**: Each bullet provides unique, concise information - no fluff
 - **Business context**: Connect technical changes to business value
 - **Issue linking**: Use separate "closes #X" for each resolved issue
-- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode
 
 ---
 
-> GitHub Pull Request Generation Skill v3.0.0 - KemingHe/common-devx
+> GitHub Pull Request Generation Skill v3.1.0 - KemingHe/common-devx

--- a/agent-skills/meeting-agenda/SKILL.md
+++ b/agent-skills/meeting-agenda/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Meeting Agenda Generation
@@ -73,16 +73,28 @@ Iterate based on feedback.
 
 Present agenda in markdown code block following discovered template structure.
 
-## Constraints
+## General Doc Constraints
+
+Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
+
+- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
+- **Bullets**: Use dash (`-`) for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line; split into separate distinct bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted.
+- **Prose lines**: One sentence per line; never wrap mid-sentence to a continuation line
+- **Optional sections**: Strip `(optional)` or any parenthetical conditional label (e.g., `(if operational)`) from section headers when populating; omit the entire section (header and body) when unused
+- **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections
+- **Completeness**: Populate all template placeholders with actual content; do not leave bracketed placeholders (e.g., `[Job Title]`), `[TODO]`, or `[TBD]` in generated output
+- **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap
+
+> General Doc Constraints v1.0.0 - KemingHe/common-devx
+
+## Skill Constraints
 
 - **Template as scaffold**: Use discovered templates as minimum structure, enrich appropriately
 - **Time realism**: Allocations should sum to total duration, include buffer
 - **Clear ownership**: Each topic should have a lead
 - **Preparation clarity**: List specific materials, links, or tasks for attendees
 - **Outcome focus**: Define what decisions or deliverables are expected
-- **KISS and DRY**: Each topic conveys unique purpose - no redundant items
-- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode
 
 ---
 
-> Meeting Agenda Generation Skill v1.0.0 - KemingHe/common-devx
+> Meeting Agenda Generation Skill v1.1.0 - KemingHe/common-devx

--- a/agent-skills/meeting-memo/SKILL.md
+++ b/agent-skills/meeting-memo/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "3.0.0"
+  version: "3.1.0"
 ---
 
 # Meeting Memo Generation
@@ -77,18 +77,31 @@ Iterate based on feedback while maintaining structure.
 
 Present memo in markdown code block following discovered template structure.
 
-## Constraints
+## General Doc Constraints
+
+Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
+
+- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
+- **Bullets**: Use dash (`-`) for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line; split into separate distinct bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted.
+- **Prose lines**: One sentence per line; never wrap mid-sentence to a continuation line
+- **Optional sections**: Strip `(optional)` or any parenthetical conditional label (e.g., `(if operational)`) from section headers when populating; omit the entire section (header and body) when unused
+- **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections
+- **Completeness**: Populate all template placeholders with actual content; do not leave bracketed placeholders (e.g., `[Job Title]`), `[TODO]`, or `[TBD]` in generated output
+- **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap
+
+> General Doc Constraints v1.0.0 - KemingHe/common-devx
+
+## Skill Constraints
 
 - **Template as scaffold**: Use discovered templates as minimum structure, enrich appropriately
 - **Completeness**: Capture all decisions, actions, discussions from source material
 - **Information fidelity**: Preserve quotes, data points, technical terms exactly
-- **KISS and DRY**: Each bullet conveys unique information - no redundancy
 - **Appropriate length**: Longer memos acceptable when content requires it
 - **Decision hierarchy**: Rank by impact, not meeting sequence
 - **Attribution**: Attribute credibility-dependent info, skip for established facts
 - **Action clarity**: Include ownership and deadlines when specified
-- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode
+- **Characters exception**: `memo-template.md` uses 🔴🟠🟡🟢 as functional priority indicators in the ACTION ITEMS table - these are permitted per template
 
 ---
 
-> Meeting Memo Generation Skill v3.0.0 - KemingHe/common-devx
+> Meeting Memo Generation Skill v3.1.0 - KemingHe/common-devx

--- a/agent-skills/meeting-memo/assets/standup-template.md
+++ b/agent-skills/meeting-memo/assets/standup-template.md
@@ -10,10 +10,10 @@
 
 - [ ] Task in progress (X hr to spend)
 
-## Blockers (Optional)
+## Blockers (optional)
 
 - Issue/blocker description
 
 ---
 
-> Standup Template v2.0.0 - KemingHe/common-devx
+> Standup Template v2.0.1 - KemingHe/common-devx

--- a/agent-skills/readme/README.md
+++ b/agent-skills/readme/README.md
@@ -1,6 +1,6 @@
 # README - README Generation
 
-> **Last Updated**: 2026-02-05 by Keming He
+> **Last Updated**: 2026-02-22 by Keming He
 
 AI skill for generating self-contained directory READMEs that enable developers to instantly understand any part of a codebase without reading parent documentation.
 

--- a/agent-skills/readme/SKILL.md
+++ b/agent-skills/readme/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "2.1.0"
+  version: "2.2.0"
 ---
 
 # README Generation
@@ -120,16 +120,28 @@ Ask: "If a dev lands here with zero context, do they understand in 30 seconds?"
 
 Present README in markdown following template structure. Target ~50 lines, max 100.
 
-## Constraints
+## General Doc Constraints
+
+Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
+
+- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
+- **Bullets**: Use dash (`-`) for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line; split into separate distinct bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted.
+- **Prose lines**: One sentence per line; never wrap mid-sentence to a continuation line
+- **Optional sections**: Strip `(optional)` or any parenthetical conditional label (e.g., `(if operational)`) from section headers when populating; omit the entire section (header and body) when unused
+- **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections
+- **Completeness**: Populate all template placeholders with actual content; do not leave bracketed placeholders (e.g., `[Job Title]`), `[TODO]`, or `[TBD]` in generated output
+- **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap
+
+> General Doc Constraints v1.0.0 - KemingHe/common-devx
+
+## Skill Constraints
 
 - **Self-contained**: README makes sense without parent context
 - **30-second rule**: Purpose clear at first scan
 - **Non-recursive**: Document THIS level only, link to subdirectory READMEs
 - **Pattern over listing**: Consider documenting naming patterns for large directories
 - **Link to README.md**: Use `[Dir](../dir/README.md)` not `../dir/`
-- **KISS and DRY**: Say it once, link elsewhere
-- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode
 
 ---
 
-> README Generation Skill v2.1.0 - KemingHe/common-devx
+> README Generation Skill v2.2.0 - KemingHe/common-devx

--- a/agent-skills/senior-mentor/SKILL.md
+++ b/agent-skills/senior-mentor/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Senior Mentor
@@ -145,7 +145,7 @@ If user says EMERGENCY_ANSWER (all caps with underscore), provide the direct ans
 - Never proactively mention the safe word
 - Hint only after 3+ stuck cycles: "There is an emergency exit if needed"
 
-## Constraints
+## Skill Constraints
 
 - **No direct answers**: Never break except via safe word
 - **One question per turn**: No multi-part questions
@@ -200,4 +200,4 @@ Mentor: "What OSI layer does each operate at?"
 
 ---
 
-> Senior Mentor Skill v1.0.0 - KemingHe/common-devx
+> Senior Mentor Skill v1.1.0 - KemingHe/common-devx

--- a/agent-skills/skill-creation/README.md
+++ b/agent-skills/skill-creation/README.md
@@ -1,6 +1,6 @@
 # README - Skill Creation
 
-> **Last Updated**: 2026-02-16 by Keming He
+> **Last Updated**: 2026-02-22 by Keming He
 
 Create or refactor Agent Skills following the agentskills.io specification.
 

--- a/agent-skills/skill-creation/SKILL.md
+++ b/agent-skills/skill-creation/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "1.2.0"
+  version: "1.3.0"
 ---
 
 # Skill Creation
@@ -115,7 +115,21 @@ When creating a skill, produce three files:
 
 Present each file in a markdown code block with the filename as header.
 
-## Constraints
+## General Doc Constraints
+
+Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
+
+- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
+- **Bullets**: Use dash (`-`) for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line; split into separate distinct bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted.
+- **Prose lines**: One sentence per line; never wrap mid-sentence to a continuation line
+- **Optional sections**: Strip `(optional)` or any parenthetical conditional label (e.g., `(if operational)`) from section headers when populating; omit the entire section (header and body) when unused
+- **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections
+- **Completeness**: Populate all template placeholders with actual content; do not leave bracketed placeholders (e.g., `[Job Title]`), `[TODO]`, or `[TBD]` in generated output
+- **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap
+
+> General Doc Constraints v1.0.0 - KemingHe/common-devx
+
+## Skill Constraints
 
 - **Frontmatter**: Must be valid YAML with `name` and `description`
 - **Name matching**: Directory name must equal `name` field
@@ -123,7 +137,6 @@ Present each file in a markdown code block with the filename as header.
 - **Token budget**: Body should be <5000 tokens for efficient loading
 - **Progressive disclosure**: Only essential instructions in SKILL.md; details in assets/references
 - **Asset resolution**: Always instruct to check local `./assets/` first, then search
-- **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
 
 ## Specification Reference
 
@@ -150,4 +163,4 @@ Full specification: [agentskills.io/specification](https://agentskills.io/specif
 
 ---
 
-> Skill Creation Skill v1.2.0 - KemingHe/common-devx
+> Skill Creation Skill v1.3.0 - KemingHe/common-devx

--- a/agent-skills/skill-creation/assets/skill-template.md
+++ b/agent-skills/skill-creation/assets/skill-template.md
@@ -69,10 +69,23 @@ This skill performs read-only reconnaissance. Never modify [system] state.
 [Expected output structure with placeholders]
 ```
 
-## Constraints
+## General Doc Constraints
+
+Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
 - **Characters**: QWERTY keyboard typeable only - no em-dashes, smart quotes, emojis, or special Unicode. Exception: `↑` for ToC navigation
-- [Constraint 1: e.g., character limits, format requirements]
+- **Bullets**: Use dash (`-`) for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line; split into separate distinct bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted.
+- **Prose lines**: One sentence per line; never wrap mid-sentence to a continuation line
+- **Optional sections**: Strip `(optional)` or any parenthetical conditional label (e.g., `(if operational)`) from section headers when populating; omit the entire section (header and body) when unused
+- **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections
+- **Completeness**: Populate all template placeholders with actual content; do not leave bracketed placeholders (e.g., `[Job Title]`), `[TODO]`, or `[TBD]` in generated output
+- **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap
+
+> General Doc Constraints v1.0.0 - KemingHe/common-devx
+
+## Skill Constraints
+
+- [Constraint 1: e.g., character limits, format requirements specific to this skill]
 - [Constraint 2: e.g., what NOT to do]
 - [Constraint 3: e.g., required validations]
 


### PR DESCRIPTION
closes #46
closes #47

CHANGES
- Add ## General Doc Constraints section (7 rules) to all 8 output-generating skills and documentation-review
- Rename ## Constraints to ## Skill Constraints in all 10 skill files including senior-mentor
- New rules: Bullets (no soft-wrap), Prose lines (no soft-wrap), Optional sections, Consistency, Completeness
- Canonicalize existing per-skill Characters and KISS and DRY into the shared block
- Add > General Doc Constraints v1.0.0 version footer per skill for propagation tracking
- Update skill-creation/assets/skill-template.md with two-section layout for future skills
- Fix standup-template.md Blockers label from (Optional) to (optional) (v2.0.1)
- Add Output quality dimension to documentation-review checklist and README
- Update 4 skill READMEs: Last Updated to 2026-02-22, Constraints renamed to Skill Constraints

IMPACT
- Fixes bug #47: agents no longer soft-wrap bullet or prose content mid-sentence
- Fixes bug #46: (optional) labels now stripped when populated, sections omitted when unused
- meeting-memo documents 🔴🟠🟡🟢 emoji exception in Skill Constraints; canonical block stays pure
- General Doc Constraints v1.0.0 is now auditable via grep across all skills