### PR TITLE
feat(docs): add skill catalog and adoption guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,10 @@ Use [issue templates](./.github/ISSUE_TEMPLATE/) to describe your proposed chang
 
 | Issue Type | When to Proceed |
 | :--- | :--- |
-| Bug fix | When maintainer confirmed as valid bug |
-| Feature request | When maintainer commented with approval |
+| Bug fix | After maintainer confirms it is a valid bug |
+| Feature request | After maintainer comments with approval |
 | Minor doc fix | Can proceed (typos, broken links) |
-| Significant change | When maintainer commented with approval |
+| Significant change | After maintainer comments with approval |
 
 ### 3. Branch
 
@@ -50,7 +50,8 @@ Before submitting:
 - [ ] Follows existing patterns
 - [ ] No `[TODO]` or `[TBD]` placeholders
 - [ ] Links work, frontmatter versions are correct
-- [ ] Last Updated date is current
+- [ ] `Last Updated` date is current for relevant files
+- [ ] Run [documentation-review](./.agents/skills/documentation-review/README.md) skill on changes if using an agent (recommended)
 
 ### 6. Submit PR
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ common-devx/
 Copy skill directories from `.agents/skills/` to your project. Most AI coding agents support the `.agents/skills/` path:
 
 ```shell
-# Copy a single skill
+# Copy a single skill (create directory if needed)
+mkdir -p /path/to/your-project/.agents/skills
 cp -r .agents/skills/commit-message-creation /path/to/your-project/.agents/skills/
 
-# Or copy all skills
-cp -r .agents/skills /path/to/your-project/.agents/
+# Copy all skills (warning: overwrites existing skills with same names)
+mkdir -p /path/to/your-project/.agents/skills
+cp -r .agents/skills/* /path/to/your-project/.agents/skills/
 ```
 
 - For [**Cursor**](https://cursor.com/docs/skills), also supported: `.cursor/skills/` (project) or `~/.cursor/skills/` (global).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,7 +44,7 @@ These guides apply to any Git-based workflow, not just this repository.
 For inaccurate, misleading, or problematic content:
 
 - Open a [GitHub issue](https://github.com/KemingHe/common-devx/issues) with details
-- Use the `bug report` template for specific problems
+- Choose the `Bug report` option when creating the issue
 - Include the file path and description of the issue
 
 ### Security Concerns


### PR DESCRIPTION
Improves new user onboarding by adding a browsable skill catalog and clear adoption instructions to the root README.

closes #73
closes #67

## Changes

- Add skill catalog table with 12 skills organized by category (Git Workflow, Project Management, Meta)
- Add "How to Use" section with copy-paste instructions and GitHub template option
- Restructure README for immediate value: structure, catalog, usage, then references
- Restructure CONTRIBUTING to show what contributors can do before prerequisites and rules
- Document catalog maintenance workflow for future skill additions

## Impact

- New users see what's available and how to adopt it without navigating multiple files
- Contributors understand contribution types before hitting setup requirements
- Skills are discoverable and categorized for quick scanning
- Clear adoption paths reduce friction for both individual skill adoption and full repository usage