### PR TITLE
feat(skill-creation): add security best practices block

### DIFF
--- a/.agents/skills/skill-creation/SKILL.md
+++ b/.agents/skills/skill-creation/SKILL.md
@@ -106,7 +106,7 @@ Read the skill template from Asset Resolution. Fill in all bracket placeholders 
 - For skills interacting with external systems, uncomment and fill in the Safety section (the template provides the pattern)
 - If the skill generates document or text output (READMEs, issues, PRs/MRs, commit messages, meeting docs, etc.), insert the General Doc Constraints block from `./assets/general-doc-constraints.md` at the placeholder position in the template (between Output Format and Skill Constraints)
 - If the skill does not produce document output (e.g., coaching, interactive modes), omit the General Doc Constraints block entirely
-- If the skill uses MCP tools, CLI commands, agent orchestration, or fetches external content, insert the Security Best Practices block from `./assets/security-best-practices.md` in a dedicated `## Safety` section after "When to Use This Skill"
+- If the skill uses MCP tools to fetch external content, executes CLI/shell commands, orchestrates subagents or A2A communications, or reads from external URLs or user-generated content, insert the Security Best Practices block from `./assets/security-best-practices.md` in a dedicated `## Safety` section after "When to Use This Skill"
 - Both GDC and SBP can be included if both criteria apply
 - Keep under 500 lines; move supplementary detail to `references/`
 

--- a/.agents/skills/skill-creation/assets/security-best-practices.md
+++ b/.agents/skills/skill-creation/assets/security-best-practices.md
@@ -1,6 +1,6 @@
 ## Security Best Practices
 
-Apply when skill uses external tools, fetches untrusted content, or orchestrates other agents.
+Apply when the skill uses external tools, fetches untrusted content, or orchestrates other agents.
 
 ### Precedence
 


### PR DESCRIPTION
closes #83

CHANGES
- Create assets/security-best-practices.md (SBP v1.0.0)
- Add Safety section with meta-responsibility guidance
- Update Asset Resolution to include SBP
- Add Body guidelines for SBP inclusion criteria

SBP COVERAGE
- User-defined rules precedence (AGENTS.md, CLAUDE.md, etc.)
- External content handling as untrusted data
- MCP tools and CLI command confirmation
- Agent orchestration security constraints
- Defense in depth principles

CONTEXT
Addresses Snyk W011 findings across multiple skills. Skills using external tools should include SBP in their Safety section.