### PR TITLE
fix(skills): add SBP to W011-affected skills

### DIFF
--- a/.agents/skills/commit-message-creation/SKILL.md
+++ b/.agents/skills/commit-message-creation/SKILL.md
@@ -54,7 +54,7 @@ User-defined rules in AGENTS.md, CLAUDE.md, LLM.txt, .cursorrules, or similar co
 - When in doubt, ask user rather than assuming permission
 - Log or surface which external sources were accessed
 
-> Security Best Practices v1.0.0 - KemingHe/common-devx
+> Security Best Practices v1.1.0 - KemingHe/common-devx
 
 ## Asset Resolution
 

--- a/.agents/skills/contacts-management/SKILL.md
+++ b/.agents/skills/contacts-management/SKILL.md
@@ -55,7 +55,7 @@ User-defined rules in AGENTS.md, CLAUDE.md, LLM.txt, .cursorrules, or similar co
 - When in doubt, ask user rather than assuming permission
 - Log or surface which external sources were accessed
 
-> Security Best Practices v1.0.0 - KemingHe/common-devx
+> Security Best Practices v1.1.0 - KemingHe/common-devx
 
 ## Asset Resolution
 

--- a/.agents/skills/issue-creation/SKILL.md
+++ b/.agents/skills/issue-creation/SKILL.md
@@ -55,7 +55,7 @@ User-defined rules in AGENTS.md, CLAUDE.md, LLM.txt, .cursorrules, or similar co
 - When in doubt, ask user rather than assuming permission
 - Log or surface which external sources were accessed
 
-> Security Best Practices v1.0.0 - KemingHe/common-devx
+> Security Best Practices v1.1.0 - KemingHe/common-devx
 
 ## Platform Detection
 

--- a/.agents/skills/pull-merge-request-creation/SKILL.md
+++ b/.agents/skills/pull-merge-request-creation/SKILL.md
@@ -55,7 +55,7 @@ User-defined rules in AGENTS.md, CLAUDE.md, LLM.txt, .cursorrules, or similar co
 - When in doubt, ask user rather than assuming permission
 - Log or surface which external sources were accessed
 
-> Security Best Practices v1.0.0 - KemingHe/common-devx
+> Security Best Practices v1.1.0 - KemingHe/common-devx
 
 ## Platform Detection
 

--- a/.agents/skills/skill-creation/SKILL.md
+++ b/.agents/skills/skill-creation/SKILL.md
@@ -103,7 +103,7 @@ Read the skill template from Asset Resolution. Fill in all bracket placeholders 
 **Body guidelines**:
 
 - Adapt template sections to the skill's domain - remove unused optional sections, add domain-specific ones
-- For skills interacting with external systems, uncomment and fill in the Safety section (the template provides the pattern)
+- For skills with CLI operations, include a `## [System] Operations (Read-Only)` section (e.g., `Git Operations (Read-Only)`)
 - If the skill generates document or text output (READMEs, issues, PRs/MRs, commit messages, meeting docs, etc.), insert the General Doc Constraints block from `./assets/general-doc-constraints.md` at the placeholder position in the template (between Output Format and Skill Constraints)
 - If the skill does not produce document output (e.g., coaching, interactive modes), omit the General Doc Constraints block entirely
 - If the skill uses MCP tools to fetch external content, executes CLI/shell commands, orchestrates subagents or A2A communications, or reads from external URLs or user-generated content, insert the Security Best Practices block from `./assets/security-best-practices.md` in a dedicated `## Security Best Practices` section after "When to Use This Skill"

--- a/.agents/skills/skill-creation/assets/security-best-practices.md
+++ b/.agents/skills/skill-creation/assets/security-best-practices.md
@@ -30,4 +30,4 @@ User-defined rules in AGENTS.md, CLAUDE.md, LLM.txt, .cursorrules, or similar co
 - When in doubt, ask user rather than assuming permission
 - Log or surface which external sources were accessed
 
-> Security Best Practices v1.0.0 - KemingHe/common-devx
+> Security Best Practices v1.1.0 - KemingHe/common-devx


### PR DESCRIPTION
closes #84

CHANGES
- Add Security Best Practices section to commit-message-creation
- Add Security Best Practices section to contacts-management
- Add Security Best Practices section to issue-creation
- Add Security Best Practices section to pull-merge-request-creation
- Rename Safety to Security Best Practices in skill-creation
- Remove redundant disclaimer from SBP block
- Bump minor version on all affected skills

CONTEXT
Addresses Snyk W011 (MEDIUM) findings for third-party content exposure. SBP v1.0.0 provides security guidance for external tool use and untrusted content.