### PR TITLE
refactor(readme-creation): remove Last Updated from template

### DIFF
--- a/.agents/skills/commit-message-creation/README.md
+++ b/.agents/skills/commit-message-creation/README.md
@@ -1,7 +1,5 @@
 # README - Commit Message Generation
 
-> **Last Updated**: 2026-02-26 by Keming He
-
 Generate conventional commit messages by analyzing staged changes and repository context.
 
 ## Quick Start

--- a/.agents/skills/contacts-management/README.md
+++ b/.agents/skills/contacts-management/README.md
@@ -1,7 +1,5 @@
 # README - Contact Management
 
-> **Last Updated**: 2026-02-26 by Keming He
-
 Manage contact information by adding, updating, or validating entries from various sources.
 
 ## Quick Start

--- a/.agents/skills/documentation-review/README.md
+++ b/.agents/skills/documentation-review/README.md
@@ -1,7 +1,5 @@
 # README - Documentation Review
 
-> **Last Updated**: 2026-02-26 by Keming He
-
 Review and correct documentation for consistency, correctness, and drift. Documentation edits only - no functional code changes.
 
 ## Quick Start

--- a/.agents/skills/dot-gitlab-sync/README.md
+++ b/.agents/skills/dot-gitlab-sync/README.md
@@ -1,7 +1,5 @@
 # README - GitHub-GitLab Template Sync
 
-> **Last Updated**: 2026-02-26 by Keming He
-
 Synchronize `.github/` and `.gitlab/` template directories with automatic platform-specific transformations. Handles YAML frontmatter, terminology (PR/MR), directory structure, and template naming differences.
 
 ## Quick Start

--- a/.agents/skills/issue-creation/README.md
+++ b/.agents/skills/issue-creation/README.md
@@ -1,7 +1,5 @@
 # README - Issue Generation
 
-> **Last Updated**: 2026-02-26 by Keming He
-
 Generate issues following repository templates for bug reports, feature requests, and enhancements. Supports both GitHub and GitLab with automatic platform detection.
 
 ## Quick Start

--- a/.agents/skills/living-design-documents/README.md
+++ b/.agents/skills/living-design-documents/README.md
@@ -1,7 +1,5 @@
 # README - Living Design Documents
 
-> **Last Updated**: 2026-03-19 by Keming He
-
 Create and maintain three living design documents (Core Decisions, Taxonomy, Parked) that guide development through structured design thinking. Documents graduate upward as content matures from deferred analysis to detailed specifications to load-bearing policies.
 
 ## Quick Start

--- a/.agents/skills/meeting-agenda-creation/README.md
+++ b/.agents/skills/meeting-agenda-creation/README.md
@@ -1,7 +1,5 @@
 # README - Meeting Agenda Generation
 
-> **Last Updated**: 2026-02-26 by Keming He
-
 Generate meeting agendas that structure discussions, allocate time, and set expectations for attendees.
 
 ## Quick Start

--- a/.agents/skills/meeting-memo-creation/README.md
+++ b/.agents/skills/meeting-memo-creation/README.md
@@ -1,7 +1,5 @@
 # README - Meeting Memo Generation
 
-> **Last Updated**: 2026-02-26 by Keming He
-
 Generate meeting memos that capture decisions, actions, and key discussions following project templates.
 
 ## Quick Start

--- a/.agents/skills/pull-merge-request-creation/README.md
+++ b/.agents/skills/pull-merge-request-creation/README.md
@@ -1,7 +1,5 @@
 # README - Pull/Merge Request Generation
 
-> **Last Updated**: 2026-02-26 by Keming He
-
 Generate pull request (GitHub) or merge request (GitLab) descriptions following repository templates to communicate changes, impact, and value. Supports both GitHub and GitLab with automatic platform detection.
 
 ## Quick Start

--- a/.agents/skills/readme-creation/README.md
+++ b/.agents/skills/readme-creation/README.md
@@ -1,12 +1,10 @@
 # README - README Generation
 
-> **Last Updated**: 2026-02-26 by Keming He
-
 AI skill for generating self-contained directory READMEs that enable developers to instantly understand any part of a codebase without reading parent documentation.
 
 ## Why This Matters
 
-READMEs are **entry points**, not documentation. A developer landing on any directory should understand its purpose within 30 seconds - without needing to read the parent first.
+READMEs are **entry points**, not full documentation. A developer landing on any directory should understand its purpose within 30 seconds - without needing to read the parent first.
 
 | Principle | What It Means |
 | :--- | :--- |
@@ -17,17 +15,13 @@ READMEs are **entry points**, not documentation. A developer landing on any dire
 ## Directory Structure
 
 ```plaintext
-readme/
-├── SKILL.md                    # AI instructions + philosophy
-├── README.md                   # This file (demonstrates the pattern)
-└── assets/
-    └── readme-template.md      # Template for generating READMEs
+readme-creation/
+├── assets/
+│   ├── readme-template.md           # Template for generating READMEs
+│   └── upgrade-from-*.md            # Migration guides for breaking changes
+├── README.md
+└── SKILL.md                         # AI instructions + philosophy
 ```
-
-## Quick Links
-
-- [`SKILL.md`](./SKILL.md) - Full generation process and anti-patterns
-- [`assets/readme-template.md`](./assets/readme-template.md) - Copy-paste starting point
 
 ## Getting Started
 
@@ -38,3 +32,9 @@ Create a README for [directory-path]
 ```
 
 The AI will analyze the directory and generate a self-contained README following the template.
+
+## Quick Links
+
+- [`SKILL.md`](./SKILL.md) - Full generation process and anti-patterns
+- [`assets/readme-template.md`](./assets/readme-template.md) - Copy-paste starting point
+- [`assets/upgrade-from-v3-0-0.md`](./assets/upgrade-from-v3-0-0.md) - Remove "Last Updated" from legacy READMEs

--- a/.agents/skills/readme-creation/SKILL.md
+++ b/.agents/skills/readme-creation/SKILL.md
@@ -7,7 +7,7 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "3.0.0"
+  version: "3.1.0"
 ---
 
 # README Generation
@@ -21,6 +21,10 @@ Generate self-contained README files that enable developers to instantly underst
 - Creating README for a new directory
 - Updating existing README after structural changes
 - Ensuring consistent documentation across repository
+
+## Upgrade Guides
+
+Check `./assets/upgrade-from-*.md` for migration instructions when updating READMEs created with older skill versions.
 
 ## Core Philosophy
 
@@ -74,9 +78,11 @@ Use your judgment - patterns work well for consistent naming conventions, explic
 **Preferred**: Use `tree` command for hierarchical view (may not be installed on all systems):
 
 ```shell
-tree -L 2 [directory]          # 2-level depth
-tree -L 1 --dirsfirst          # Directories first, 1 level
+tree -L 2 --dirsfirst [directory]   # 2-level depth, directories first
+tree -L 1 --dirsfirst               # 1 level, directories first
 ```
+
+**Tree ordering convention**: Directories first (lexicographically), then files (lexicographically). This matches common IDE file explorers and `tree --dirsfirst` output.
 
 **Fallback**: Use `ls` or IDE file listing for flat view.
 
@@ -123,7 +129,7 @@ Root READMEs are a special case requiring additional context gathering. Auto-det
 
 Structure for scannability:
 
-1. **Title + metadata** - identity
+1. **Title** - identity
 2. **Overview** - what and why (most critical - first thing devs read)
 3. **Directory structure or patterns** - what's here (this level only)
 4. **Quick links** - where to go next

--- a/.agents/skills/readme-creation/assets/readme-template.md
+++ b/.agents/skills/readme-creation/assets/readme-template.md
@@ -1,16 +1,14 @@
 # README - [Directory Name]
 
-> **Last Updated**: [YYYY-MM-DD] by [First Name Last Name]
-
 [1-2 sentence answer to: "What is this directory and why does it exist?"]
 
 ## Directory Structure
 
 ```plaintext
 [directory-name]/
-├── [file-or-subdir]/     # [Purpose - what problem it solves]
-├── [file-or-subdir]/     # [Purpose - see subdir/README.md for details]
-└── README.md             # This file
+├── [subdir]/             # [Purpose - see subdir/README.md for details]
+├── [file.ext]            # [Purpose - what problem it solves]
+└── README.md
 ```
 
 ## Quick Links

--- a/.agents/skills/readme-creation/assets/upgrade-from-v3-0-0.md
+++ b/.agents/skills/readme-creation/assets/upgrade-from-v3-0-0.md
@@ -1,0 +1,49 @@
+# Upgrade from v3.0.0
+
+Migration guide for READMEs created with readme-creation skill v3.0.0 or earlier.
+
+## Breaking Changes in v3.1.0
+
+**Removed**: "Last Updated" metadata line from template.
+
+**Rationale**: Git tracks file history via `git log -1 --format="%ai %an" -- README.md`. Manual dates create ambiguity (content freshness vs file modification) and maintenance burden.
+
+## Migration Steps
+
+### Step 1: Identify Affected READMEs
+
+Search for READMEs with the legacy pattern:
+
+```shell
+grep -r "Last Updated" **/README.md
+```
+
+### Step 2: Remove Legacy Pattern
+
+Remove this line from each affected README (typically line 3):
+
+```plaintext
+> **Last Updated**: YYYY-MM-DD by First Last
+```
+
+Also remove the blank line that follows it.
+
+### Step 3: Verify
+
+After removal, READMEs should start with:
+
+```markdown
+# README - [Title]
+
+[Description paragraph]
+```
+
+Not:
+
+```markdown
+# README - [Title]
+
+> **Last Updated**: 2025-01-15 by Jane Doe
+
+[Description paragraph]
+```

--- a/.agents/skills/readme-creation/assets/upgrade-from-v3-0-0.md
+++ b/.agents/skills/readme-creation/assets/upgrade-from-v3-0-0.md
@@ -15,7 +15,7 @@ Migration guide for READMEs created with readme-creation skill v3.0.0 or earlier
 Search for READMEs with the legacy pattern:
 
 ```shell
-grep -r "Last Updated" **/README.md
+grep -R --include="README.md" "Last Updated" .
 ```
 
 ### Step 2: Remove Legacy Pattern

--- a/.agents/skills/senior-mentor/README.md
+++ b/.agents/skills/senior-mentor/README.md
@@ -1,7 +1,5 @@
 # README - Senior Mentor
 
-> **Last Updated**: 2026-03-31 by Keming He
-
 Transform into a senior mentor with 15+ years expertise for peer-level guidance. Default mode provides direct advice with solution rankings. Opt-in Socratic mode available for guided learning through questioning.
 
 ## Quick Start

--- a/.agents/skills/skill-creation/README.md
+++ b/.agents/skills/skill-creation/README.md
@@ -1,7 +1,5 @@
 # README - Skill Creation
 
-> **Last Updated**: 2026-02-26 by Keming He
-
 Create or refactor Agent Skills following the agentskills.io specification.
 
 ## Quick Start

--- a/human-guides/README.md
+++ b/human-guides/README.md
@@ -1,7 +1,5 @@
 # README - Human Guides
 
-> **Last Updated**: 2026-03-21 by Keming He
-
 Reference documentation for developers - workflows, troubleshooting, and diagnostic guides. Human-readable (not AI skills).
 
 ## Platform Support


### PR DESCRIPTION
closes #91

CHANGES
- Remove Last Updated line from readme-template.md
- Bump skill version 3.0.0 to 3.1.0
- Add upgrade guide pattern with assets/upgrade-from-v3-0-0.md
- Add tree ordering convention (directories first, then files)
- Remove Last Updated from 13 existing READMEs

IMPACT
- Git history tracks file changes - manual dates redundant
- Reduces maintenance burden on documentation updates
- Establishes upgrade guide pattern for future breaking changes