### PR TITLE
fix(gdc): add Unicode box drawing exception and bump to v1.2.0

### DIFF
--- a/.agents/skills/commit-message-creation/SKILL.md
+++ b/.agents/skills/commit-message-creation/SKILL.md
@@ -160,7 +160,7 @@ type(scope): brief description in imperative mood
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -168,7 +168,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/contacts-management/SKILL.md
+++ b/.agents/skills/contacts-management/SKILL.md
@@ -142,7 +142,7 @@ Present contact entry in markdown following template structure:
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -150,7 +150,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/documentation-review/README.md
+++ b/.agents/skills/documentation-review/README.md
@@ -18,7 +18,7 @@ Ask your AI agent to review documentation:
 | Correctness | Valid YAML, working links |
 | Completeness | Required sections, no placeholders |
 | Freshness | Last Updated dates, versions |
-| Characters | QWERTY-only everywhere; no smart quotes, emojis, or special Unicode; no em-dashes or `--`/` -- ` in prose; use ` - ` for separation. Exception: `↑` |
+| Characters | QWERTY-only everywhere; no smart quotes, emojis, or special Unicode; no em-dashes or `--`/` -- ` in prose; use ` - ` for separation. Exceptions: `↑`; box drawing for `tree` output |
 | Inline formatting | `_underscore_` italics; colon outside bold (`**Topic**:`) |
 | Linter | IDE/editor warnings when available |
 | Output quality | Hard-wrapped bullets or prose that simulate visual wrapping; sentences broken across hard newlines; orphaned `(optional)` labels; unfilled `[placeholder]` text |

--- a/.agents/skills/documentation-review/SKILL.md
+++ b/.agents/skills/documentation-review/SKILL.md
@@ -7,7 +7,9 @@ description: |
 license: MIT
 metadata:
   author: KemingHe
-  version: "2.0.0"
+  contributors:
+    - puneetdixit200
+  version: "2.1.0"
 ---
 
 # Documentation Review
@@ -40,7 +42,7 @@ Determine files to review:
 | **Correctness** | Valid YAML/markdown, working links, accurate paths |
 | **Completeness** | Required sections present, no unfilled placeholders |
 | **Freshness** | Last Updated date, version numbers, changelog entries |
-| **Characters** | QWERTY-only everywhere; no smart quotes, emojis, or special Unicode; no em-dashes or em-dash substitutes (`--`, ` -- `) in prose; use ` - ` for clause separation (exception: `↑`) |
+| **Characters** | QWERTY-only everywhere; no smart quotes, emojis, or special Unicode; no em-dashes or em-dash substitutes (`--`, ` -- `) in prose; use ` - ` for clause separation (exceptions: `↑`; box drawing for `tree` output) |
 | **Inline formatting** | `_underscore_` italics only; colon outside bold label markers (`**Topic**:`) |
 | **Linter** | Check IDE/editor linter errors when available |
 | **Output quality** | Hard-wrapped bullets or prose that simulate visual wrapping; sentences broken across hard newlines; orphaned `(optional)` labels in populated sections; unfilled `[placeholder]` text; terminology inconsistency; KISS/DRY violations |

--- a/.agents/skills/documentation-review/SKILL.md
+++ b/.agents/skills/documentation-review/SKILL.md
@@ -88,7 +88,7 @@ Summarize with:
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -96,7 +96,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/dot-gitlab-sync/SKILL.md
+++ b/.agents/skills/dot-gitlab-sync/SKILL.md
@@ -83,7 +83,7 @@ Report clean status or list remaining discrepancies.
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -91,7 +91,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/issue-creation/SKILL.md
+++ b/.agents/skills/issue-creation/SKILL.md
@@ -142,7 +142,7 @@ feat(component): brief description
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -150,7 +150,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/living-design-documents/SKILL.md
+++ b/.agents/skills/living-design-documents/SKILL.md
@@ -198,7 +198,7 @@ Present all generated or updated design documents as complete markdown code bloc
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -206,7 +206,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/meeting-agenda-creation/SKILL.md
+++ b/.agents/skills/meeting-agenda-creation/SKILL.md
@@ -77,7 +77,7 @@ Present agenda in markdown code block following discovered template structure.
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -85,7 +85,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/meeting-memo-creation/SKILL.md
+++ b/.agents/skills/meeting-memo-creation/SKILL.md
@@ -81,7 +81,7 @@ Present memo in markdown code block following discovered template structure.
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -89,7 +89,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/next-session-handoff/SKILL.md
+++ b/.agents/skills/next-session-handoff/SKILL.md
@@ -155,7 +155,7 @@ Present the filled handoff document in a markdown code block. The output is for 
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -163,7 +163,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/pull-merge-request-creation/SKILL.md
+++ b/.agents/skills/pull-merge-request-creation/SKILL.md
@@ -174,7 +174,7 @@ type(scope): brief description
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -182,7 +182,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/readme-creation/SKILL.md
+++ b/.agents/skills/readme-creation/SKILL.md
@@ -153,7 +153,7 @@ Present README in markdown following template structure. Target ~50 lines, max 1
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -161,7 +161,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/skill-creation/SKILL.md
+++ b/.agents/skills/skill-creation/SKILL.md
@@ -135,7 +135,7 @@ Present each file in a markdown code block with the filename as header.
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -143,7 +143,7 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx
 
 ## Skill Constraints
 

--- a/.agents/skills/skill-creation/assets/general-doc-constraints.md
+++ b/.agents/skills/skill-creation/assets/general-doc-constraints.md
@@ -2,7 +2,7 @@
 
 Apply to all generated output. If a discovered template deviates from any rule (e.g., uses emojis semantically, uses a different bullet convention), note the deviation explicitly and confirm with the user before treating it as a permitted exception.
 
-- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exception: `↑` for ToC navigation.
+- **Characters**: QWERTY keyboard typeable only - no smart quotes, emojis, or special Unicode anywhere. In prose, do not use em-dashes or em-dash substitutes (`--`, ` -- `); use ` - ` (space-dash-space) for clause separation instead. Exceptions: `↑` for ToC navigation; Unicode box drawing characters for `tree`-style directory rendering.
 - **Inline formatting**: Use `_underscore_` for italics, not `*single-star*`. Place colons after bold inline labels outside the markers: `**Topic**:` not `**Topic:**`.
 - **Bullets**: Use `-` for all unordered lists; one bullet per complete thought; never wrap a bullet's content mid-sentence onto a continuation line - split into separate bullets if too long or multi-thought. Nested sub-bullets for component grouping are permitted. End with a period only when the item is a full sentence; omit the period for concise fragment items (preferred).
 - **Prose**: Do not insert hard newlines to simulate visual wrapping. Keep each prose paragraph on one continuous physical line and let editors or viewers wrap it visually. Exception: commit message bodies use one sentence per line for `git log` readability.
@@ -10,4 +10,4 @@ Apply to all generated output. If a discovered template deviates from any rule (
 - **Consistency**: Use the same term for the same concept throughout; match the voice and tense of the template; do not mix header levels for parallel sections.
 - **KISS and DRY**: Each section and bullet conveys unique information - no redundancy or overlap.
 
-> General Doc Constraints v1.1.1 - KemingHe/common-devx
+> General Doc Constraints v1.2.0 - KemingHe/common-devx


### PR DESCRIPTION
Resolve GDC Characters constraint ambiguity for tree-style directory rendering used by doc-generation skills, and bump documentation-review metadata to credit external contributor.

closes #99
closes #105

## Changes

- Add Unicode box drawing characters as named exception in GDC Characters constraint alongside existing `↑` exception
- Bump canonical GDC from v1.1.1 to v1.2.0
- Propagate updated GDC section across all 13 embedded copies (whole-section replace)
- Bump documentation-review skill from 2.0.0 to 2.1.0 for checklist logic change introduced in PR #104
- Add `contributors` field to documentation-review frontmatter crediting puneetdixit200
- Update Characters checklist rows in documentation-review SKILL.md and README.md

## Impact

- Doc-generation skills no longer produce ambiguous constraint violations when rendering `tree --dirsfirst` output
- Completes the GDC fix cycle started in PR #104 (prose wrapping) - both known constraint bugs now resolved

## Notes

- 14 files changed across 13 skills; all diffs are mechanical replacements except documentation-review which also gets metadata updates
- After merge, common-devx enters maintenance-only mode through mid-July 2026 (no new features, no external PR reviews)